### PR TITLE
As a plugin user I need to have configurable property for Ignoring mixed case, upper case, camel case etc...  These properties must be placed on  separate "Spell checker" tab.

### DIFF
--- a/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
+++ b/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
@@ -10,6 +10,7 @@ import name.webdizz.sonar.grammar.spellcheck.GrammarDictionaryLoader;
 import name.webdizz.sonar.grammar.spellcheck.JavaSourceCodeWordFinder;
 import org.sonar.api.Properties;
 import org.sonar.api.Property;
+import org.sonar.api.PropertyType;
 import org.sonar.api.SonarPlugin;
 
 import java.util.Arrays;
@@ -35,7 +36,14 @@ import java.util.List;
                 key = PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY,
                 name = "Alternative dictionary",
                 description = "Alternative dictionary",
-                defaultValue = " ")
+                defaultValue = " "),
+        @Property(
+                key = PluginParameter.MIN_WORD_LENGTH,
+                name = "Minimum word length",
+                category = "Grammar Checker",
+                type = PropertyType.INTEGER,
+                description = "Defines minimum word length to analyse",
+                defaultValue = "0")
 
 })
 

--- a/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
+++ b/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
@@ -1,6 +1,5 @@
 package name.webdizz.sonar.grammar;
 
-import com.swabunga.spell.engine.Configuration;
 import name.webdizz.sonar.grammar.issue.tracking.GrammarActionDefinition;
 import name.webdizz.sonar.grammar.issue.tracking.LinkFunction;
 import name.webdizz.sonar.grammar.profile.GrammarProfileDefinition;
@@ -43,21 +42,21 @@ public class GrammarPlugin extends SonarPlugin {
                         SpellCheckerFactory.class,
                         SpellCheckerUtil.class,
 
-                        PropertyDefinition.builder(PluginParameter.MIN_WORD_LENGTH).name("Minimum word length")
+                        PropertyDefinition.builder(PluginParameter.SPELL_MINIMUMWORDLENGTH).name("Minimum word length")
                                 .type(PropertyType.INTEGER).description("Defines minimum word length to analyse")
                                 .defaultValue("0").subCategory("Spell Checker").build(),
-                        PropertyDefinition.builder(Configuration.SPELL_IGNOREMIXEDCASE).name("Ignore mixed case")
+                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREMIXEDCASE).name("Ignore mixed case")
                                 .type(PropertyType.BOOLEAN).description("Words that have mixed case are not spell " +
                                 "checked, example: 'SpellChecker'").defaultValue("false").subCategory("Spell Checker")
                                 .build(),
-                        PropertyDefinition.builder(Configuration.SPELL_IGNOREUPPERCASE).name("Ignore uppercase")
+                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREUPPERCASE).name("Ignore uppercase")
                                 .type(PropertyType.BOOLEAN).description("Words that are all upper case are not spell " +
                                 "checked, example: 'CIA'").defaultValue("true").subCategory("Spell Checker").build(),
-                        PropertyDefinition.builder(Configuration.SPELL_IGNOREDIGITWORDS)
+                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREDIGITWORDS)
                                 .name("Ignore words with digits").type(PropertyType.BOOLEAN)
                                 .description("Words that have digits in them are not spell checked, example: 'mach5'")
                                 .defaultValue("false").subCategory("Spell Checker").build(),
-                        PropertyDefinition.builder(Configuration.SPELL_IGNOREINTERNETADDRESSES)
+                        PropertyDefinition.builder(PluginParameter.SPELL_IGNOREINTERNETADDRESSES)
                                 .name("Ignore words like internet address").type(PropertyType.BOOLEAN)
                                 .description("Words that look like an Internet address are not spell checked, example:" +
                                         " 'http://www.google.com'").defaultValue("true").subCategory("Spell Checker")

--- a/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
+++ b/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
@@ -5,6 +5,9 @@ import name.webdizz.sonar.grammar.issue.tracking.LinkFunction;
 import name.webdizz.sonar.grammar.profile.GrammarProfileDefinition;
 import name.webdizz.sonar.grammar.rule.GrammarRulesDefinition;
 import name.webdizz.sonar.grammar.sensor.GrammarIssuesSensor;
+import name.webdizz.sonar.grammar.spellcheck.GrammarChecker;
+import name.webdizz.sonar.grammar.spellcheck.GrammarDictionaryLoader;
+import name.webdizz.sonar.grammar.spellcheck.JavaSourceCodeWordFinder;
 import org.sonar.api.Properties;
 import org.sonar.api.Property;
 import org.sonar.api.SonarPlugin;
@@ -27,7 +30,7 @@ import java.util.List;
                 key = PluginParameter.DICTIONARY_PATH,
                 name = "Dictionary path",
                 description = "Defines resources to be included for analysis",
-                defaultValue = "dict/english.0"),
+                defaultValue = "/dict/english.0"),
         @Property(
                 key = PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY,
                 name = "Alternative dictionary",
@@ -53,7 +56,11 @@ public class GrammarPlugin extends SonarPlugin {
                         GrammarIssuesSensor.class,
                         //Issue review
                         LinkFunction.class,
-                        GrammarActionDefinition.class
+                        GrammarActionDefinition.class,
+                        JavaSourceCodeWordFinder.class,
+                        GrammarChecker.class,
+                        GrammarDictionaryLoader.class
+
                 );
     }
 }

--- a/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
+++ b/src/main/java/name/webdizz/sonar/grammar/GrammarPlugin.java
@@ -1,5 +1,6 @@
 package name.webdizz.sonar.grammar;
 
+import com.swabunga.spell.engine.Configuration;
 import name.webdizz.sonar.grammar.issue.tracking.GrammarActionDefinition;
 import name.webdizz.sonar.grammar.issue.tracking.LinkFunction;
 import name.webdizz.sonar.grammar.profile.GrammarProfileDefinition;
@@ -8,44 +9,14 @@ import name.webdizz.sonar.grammar.sensor.GrammarIssuesSensor;
 import name.webdizz.sonar.grammar.spellcheck.GrammarChecker;
 import name.webdizz.sonar.grammar.spellcheck.GrammarDictionaryLoader;
 import name.webdizz.sonar.grammar.spellcheck.JavaSourceCodeWordFinder;
-import org.sonar.api.Properties;
-import org.sonar.api.Property;
+import name.webdizz.sonar.grammar.spellcheck.SpellCheckerFactory;
+import name.webdizz.sonar.grammar.utils.SpellCheckerUtil;
 import org.sonar.api.PropertyType;
 import org.sonar.api.SonarPlugin;
+import org.sonar.api.config.PropertyDefinition;
 
 import java.util.Arrays;
 import java.util.List;
-
-@Properties({
-        @Property(
-                key = PluginParameter.EXCLUSION,
-                name = "Exclusion Property",
-                description = "Defines resources to be excluded from analysis",
-                defaultValue = ""),
-        @Property(
-                key = PluginParameter.INCLUSION,
-                name = "Inclusion Property",
-                description = "Defines resources to be included for analysis",
-                defaultValue = ""),
-        @Property(
-                key = PluginParameter.DICTIONARY_PATH,
-                name = "Dictionary path",
-                description = "Defines resources to be included for analysis",
-                defaultValue = "/dict/english.0"),
-        @Property(
-                key = PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY,
-                name = "Alternative dictionary",
-                description = "Alternative dictionary",
-                defaultValue = " "),
-        @Property(
-                key = PluginParameter.MIN_WORD_LENGTH,
-                name = "Minimum word length",
-                category = "Grammar Checker",
-                type = PropertyType.INTEGER,
-                description = "Defines minimum word length to analyse",
-                defaultValue = "0")
-
-})
 
 
 public class GrammarPlugin extends SonarPlugin {
@@ -57,6 +28,7 @@ public class GrammarPlugin extends SonarPlugin {
         return Arrays
                 .asList(// Definitions
                         GrammarRulesDefinition.class,
+                        GrammarActionDefinition.class,
                         GrammarProfileDefinition.class,
                         // Metrics
                         GrammarMetrics.class,
@@ -64,11 +36,50 @@ public class GrammarPlugin extends SonarPlugin {
                         GrammarIssuesSensor.class,
                         //Issue review
                         LinkFunction.class,
-                        GrammarActionDefinition.class,
+                        //Instantiated by IoC as used injection
                         JavaSourceCodeWordFinder.class,
                         GrammarChecker.class,
-                        GrammarDictionaryLoader.class
+                        GrammarDictionaryLoader.class,
+                        SpellCheckerFactory.class,
+                        SpellCheckerUtil.class,
 
+                        PropertyDefinition.builder(PluginParameter.MIN_WORD_LENGTH).name("Minimum word length")
+                                .type(PropertyType.INTEGER).description("Defines minimum word length to analyse")
+                                .defaultValue("0").subCategory("Spell Checker").build(),
+                        PropertyDefinition.builder(Configuration.SPELL_IGNOREMIXEDCASE).name("Ignore mixed case")
+                                .type(PropertyType.BOOLEAN).description("Words that have mixed case are not spell " +
+                                "checked, example: 'SpellChecker'").defaultValue("false").subCategory("Spell Checker")
+                                .build(),
+                        PropertyDefinition.builder(Configuration.SPELL_IGNOREUPPERCASE).name("Ignore uppercase")
+                                .type(PropertyType.BOOLEAN).description("Words that are all upper case are not spell " +
+                                "checked, example: 'CIA'").defaultValue("true").subCategory("Spell Checker").build(),
+                        PropertyDefinition.builder(Configuration.SPELL_IGNOREDIGITWORDS)
+                                .name("Ignore words with digits").type(PropertyType.BOOLEAN)
+                                .description("Words that have digits in them are not spell checked, example: 'mach5'")
+                                .defaultValue("false").subCategory("Spell Checker").build(),
+                        PropertyDefinition.builder(Configuration.SPELL_IGNOREINTERNETADDRESSES)
+                                .name("Ignore words like internet address").type(PropertyType.BOOLEAN)
+                                .description("Words that look like an Internet address are not spell checked, example:" +
+                                        " 'http://www.google.com'").defaultValue("true").subCategory("Spell Checker")
+                                .build(),
+                        PropertyDefinition.builder(PluginParameter.SPELL_THRESHOLD).name("Threshold value")
+                                .type(PropertyType.INTEGER).description("The maximum cost of suggested spelling. Any " +
+                                "suggestions that cost more are thrown away").defaultValue("1")
+                                .subCategory("Spell Checker").build(),
+
+
+                        PropertyDefinition.builder(PluginParameter.EXCLUSION).name("Exclusion Property")
+                                .type(PropertyType.STRING).description("Defines resources to be excluded from analysis")
+                                .subCategory("Dictionary").defaultValue("").build(),
+                        PropertyDefinition.builder(PluginParameter.INCLUSION).name("Inclusion Property")
+                                .type(PropertyType.STRING).description("Defines resources to be included for analysis")
+                                .subCategory("Dictionary").defaultValue("").build(),
+                        PropertyDefinition.builder(PluginParameter.DICTIONARY_PATH).name("Default dictionary path")
+                                .type(PropertyType.STRING).description("Defines default dictionary path")
+                                .defaultValue("/dict/english.0").subCategory("Dictionary").build(),
+                        PropertyDefinition.builder(PluginParameter.ALTERNATIVE_DICTIONARY_PROPERTY_KEY)
+                                .name("Alternative dictionary").type(PropertyType.STRING).description("Alternative " +
+                                "dictionary").defaultValue("").subCategory("Dictionary").build()
                 );
     }
 }

--- a/src/main/java/name/webdizz/sonar/grammar/PluginParameter.java
+++ b/src/main/java/name/webdizz/sonar/grammar/PluginParameter.java
@@ -58,12 +58,6 @@ public interface PluginParameter {
     String SONAR_GRAMMAR_ISSUE_DATA_PROPERTY_KEY = "grammar-issue-key";
 
     /**
-     * manual dictionary name
-     */
-    String ALTERNATIVE_DICTIONARY_PROPERTY_KEY = "sonar.alternative.dictionary";
-
-
-    /**
      * Separator for store alternate dictionary
      */
     String SEPARATOR_CHAR = ",";
@@ -71,67 +65,69 @@ public interface PluginParameter {
      * Parameters for set cost of spelling
      */
 
-
-    //  int SPELL_THRESHOLD_VALUE = 1;
-
-    /** the maximum cost of suggested spelling. Any suggestions that cost more are thrown away
-     * integer greater than 1)
-     */
-    String SPELL_THRESHOLD = "spell.threshold.value";
-
     /**
      * exclusion word list
      **/
-    String EXCLUSION = "sonar.grammar.exclusion";
+    String EXCLUSION = "sonarqube-grammar.dictionary.exclusion";
 
     /**
      * list of words to be included to main dictionary
      **/
-    String INCLUSION = "sonar.grammar.inclusion";
+    String INCLUSION = "sonarqube-grammar.dictionary.inclusion";
 
     /**
      * path to main dictionary
      **/
-    String DICTIONARY_PATH = "sonar.grammar.dictionary";
+    String DICTIONARY_PATH = "sonarqube-grammar.dictionary.path";
+
+    /**
+     * manual dictionary name
+     */
+    String ALTERNATIVE_DICTIONARY_PROPERTY_KEY = "sonarqube-grammar.alternative.dictionary.path";
+
+    /** the maximum cost of suggested spelling. Any suggestions that cost more are thrown away
+     * integer greater than 1)
+     */
+    String SPELL_THRESHOLD = "sonarqube-grammar.spell.threshold.value";
 
     /**
      * minimum word length to be analyzed
      */
-    String SPELL_MINIMUMWORDLENGTH = "spell.minimum.word.length";
+    String SPELL_MINIMUMWORDLENGTH = "sonarqube-grammar.spell.minimum.word.length";
 
     /**
      * words that are all upper case are not spell checked, example: "CIA" <br/>(boolean)
      */
-    String SPELL_IGNOREUPPERCASE = "spell.ignore.upper.case";
+    String SPELL_IGNOREUPPERCASE = "sonarqube-grammar.spell.ignore.upper.case";
 
     /**
      * words that have mixed case are not spell checked, example: "SpellChecker"<br/>(boolean)\
      */
-    String SPELL_IGNOREMIXEDCASE = "spell.ignore.mixed.case";
+    String SPELL_IGNOREMIXEDCASE = "sonarqube-grammar.spell.ignore.mixed.case";
 
     /**
      * words that look like an Internet address are not spell checked, example: "http://www.google.com" <br/>(boolean)
      */
-    String SPELL_IGNOREINTERNETADDRESSES = "spell.ignore.internet.address";
+    String SPELL_IGNOREINTERNETADDRESSES = "sonarqube-grammar.spell.ignore.internet.address";
 
     /**
      * words that have digits in them are not spell checked, example: "mach5" <br/>(boolean)
      */
-    String SPELL_IGNOREDIGITWORDS = "spell.ignore.digit.words";
+    String SPELL_IGNOREDIGITWORDS = "sonarqube-grammar.spell.ignore.digit.words";
 
     /**
      * I don't know what this does. It doesn't seem to be used <br/>(boolean)
      */
-    String SPELL_IGNOREMULTIPLEWORDS = "spell.ignore.multiple.words";
+    String SPELL_IGNOREMULTIPLEWORDS = "sonarqube-grammar.spell.ignore.multiple.words";
 
     /**
      * the first word of a sentence is expected to start with an upper case letter <br/>(boolean)
      */
-    String SPELL_IGNORESENTENCECAPITALIZATION = "spell.ignore.sentence.capitalization";
+    String SPELL_IGNORESENTENCECAPITALIZATION = "sonarqube-grammar.spell.ignore.sentence.capitalization";
 
     /**
      * Whether to ignore words that are a single letter (common in programming)
      */
-    String SPELL_IGNORESINGLELETTERS = "SPELL_IGNORESINGLELETTERS";
+    String SPELL_IGNORESINGLELETTERS = "sonarqube-grammar.spell.ignore.single.letters";
 
 }

--- a/src/main/java/name/webdizz/sonar/grammar/PluginParameter.java
+++ b/src/main/java/name/webdizz/sonar/grammar/PluginParameter.java
@@ -70,8 +70,14 @@ public interface PluginParameter {
     /**
      * Parameters for set cost of spelling
      */
-    int SPELL_THRESHOLD_VALUE = 1;
-    String SPELL_THRESHOLD = "SPELL_THRESHOLD";
+
+
+    //  int SPELL_THRESHOLD_VALUE = 1;
+
+    /** the maximum cost of suggested spelling. Any suggestions that cost more are thrown away
+     * integer greater than 1)
+     */
+    String SPELL_THRESHOLD = "spell.threshold.value";
 
     /**
      * exclusion word list
@@ -90,7 +96,42 @@ public interface PluginParameter {
 
     /**
      * minimum word length to be analyzed
-     **/
-    String MIN_WORD_LENGTH = "sonar.minimum.word.length";
+     */
+    String SPELL_MINIMUMWORDLENGTH = "spell.minimum.word.length";
+
+    /**
+     * words that are all upper case are not spell checked, example: "CIA" <br/>(boolean)
+     */
+    String SPELL_IGNOREUPPERCASE = "spell.ignore.upper.case";
+
+    /**
+     * words that have mixed case are not spell checked, example: "SpellChecker"<br/>(boolean)\
+     */
+    String SPELL_IGNOREMIXEDCASE = "spell.ignore.mixed.case";
+
+    /**
+     * words that look like an Internet address are not spell checked, example: "http://www.google.com" <br/>(boolean)
+     */
+    String SPELL_IGNOREINTERNETADDRESSES = "spell.ignore.internet.address";
+
+    /**
+     * words that have digits in them are not spell checked, example: "mach5" <br/>(boolean)
+     */
+    String SPELL_IGNOREDIGITWORDS = "spell.ignore.digit.words";
+
+    /**
+     * I don't know what this does. It doesn't seem to be used <br/>(boolean)
+     */
+    String SPELL_IGNOREMULTIPLEWORDS = "spell.ignore.multiple.words";
+
+    /**
+     * the first word of a sentence is expected to start with an upper case letter <br/>(boolean)
+     */
+    String SPELL_IGNORESENTENCECAPITALIZATION = "spell.ignore.sentence.capitalization";
+
+    /**
+     * Whether to ignore words that are a single letter (common in programming)
+     */
+    String SPELL_IGNORESINGLELETTERS = "SPELL_IGNORESINGLELETTERS";
 
 }

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarChecker.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarChecker.java
@@ -3,7 +3,9 @@ package name.webdizz.sonar.grammar.spellcheck;
 import com.google.common.base.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.swabunga.spell.engine.Configuration;
 import com.swabunga.spell.event.SpellCheckListener;
+import name.webdizz.sonar.grammar.PluginParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,14 +15,13 @@ import com.swabunga.spell.engine.SpellDictionary;
 import com.swabunga.spell.engine.SpellDictionaryHashMap;
 import com.swabunga.spell.event.SpellChecker;
 import org.sonar.api.BatchExtension;
-
-import static name.webdizz.sonar.grammar.PluginParameter.SPELL_THRESHOLD;
-import static name.webdizz.sonar.grammar.PluginParameter.SPELL_THRESHOLD_VALUE;
+import org.sonar.api.config.Settings;
 
 
 public class GrammarChecker implements BatchExtension {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GrammarChecker.class);
+    private SpellCheckerFactory spellCheckerFactory;
     private SpellDictionary dictionary;
     private Optional<SpellDictionaryHashMap> alternateDictionary;
     private GrammarDictionaryLoader dictionaryLoader;
@@ -30,7 +31,8 @@ public class GrammarChecker implements BatchExtension {
 
 
     public GrammarChecker(final GrammarDictionaryLoader dictionaryLoader,
-                          JavaSourceCodeWordFinder javaSourceCodeWordFinder) {
+                          JavaSourceCodeWordFinder javaSourceCodeWordFinder, SpellCheckerFactory spellCheckerFactory) {
+        this.spellCheckerFactory = spellCheckerFactory;
         this.javaSourceCodeWordFinder = javaSourceCodeWordFinder;
         this.dictionaryLoader = dictionaryLoader;
     }
@@ -57,14 +59,15 @@ public class GrammarChecker implements BatchExtension {
     }
 
     private SpellChecker createSpellChecker(final SpellCheckListener spellCheckListener) {
-        SpellChecker spellCheck = new SpellCheckerFactory().getSpellChecker();
+        SpellChecker spellCheck = spellCheckerFactory.getSpellChecker();
         spellCheck.addSpellCheckListener(spellCheckListener);
-        spellCheck.getConfiguration().setInteger(SPELL_THRESHOLD, SPELL_THRESHOLD_VALUE);
         spellCheck.setUserDictionary(dictionary);
+
         if (alternateDictionary.isPresent()) {
             spellCheck.addDictionary(alternateDictionary.get());
         }
         return spellCheck;
     }
+
 
 }

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarChecker.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarChecker.java
@@ -25,7 +25,6 @@ public class GrammarChecker implements BatchExtension {
     private Optional<SpellDictionaryHashMap> alternateDictionary;
     private GrammarDictionaryLoader dictionaryLoader;
 
-    private int minimumWordLengths;
     private JavaSourceCodeWordFinder javaSourceCodeWordFinder;
 
 

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarChecker.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarChecker.java
@@ -3,9 +3,7 @@ package name.webdizz.sonar.grammar.spellcheck;
 import com.google.common.base.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.swabunga.spell.engine.Configuration;
 import com.swabunga.spell.event.SpellCheckListener;
-import name.webdizz.sonar.grammar.PluginParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +13,6 @@ import com.swabunga.spell.engine.SpellDictionary;
 import com.swabunga.spell.engine.SpellDictionaryHashMap;
 import com.swabunga.spell.event.SpellChecker;
 import org.sonar.api.BatchExtension;
-import org.sonar.api.config.Settings;
 
 
 public class GrammarChecker implements BatchExtension {

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarDictionaryLoader.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/GrammarDictionaryLoader.java
@@ -24,7 +24,6 @@ public class GrammarDictionaryLoader implements BatchExtension {
     private final Lock locker = new ReentrantLock();
     private Settings settings;
     private AtomicReference<SpellDictionary> dictionary = new AtomicReference<>();
-    private String dictionaryPath = "/dict/english.0";
 
     public GrammarDictionaryLoader(Settings settings) {
         this.settings = settings;

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/JavaSourceCodeWordFinder.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/JavaSourceCodeWordFinder.java
@@ -29,7 +29,7 @@ public class JavaSourceCodeWordFinder extends AbstractWordFinder implements Batc
      */
     public Word next() {
         if (settings != null) {
-            minimumWordLength = settings.getInt(PluginParameter.MIN_WORD_LENGTH);
+            minimumWordLength = settings.getInt(PluginParameter.SPELL_MINIMUMWORDLENGTH);
         }
 
         if (nextWord == null) {

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/SpellCheckerFactory.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/SpellCheckerFactory.java
@@ -9,7 +9,7 @@ import org.sonar.api.config.Settings;
 
 public class SpellCheckerFactory implements BatchExtension {
 
-    @Inject
+
     private Settings settings;
 
     public SpellCheckerFactory() {
@@ -23,11 +23,18 @@ public class SpellCheckerFactory implements BatchExtension {
     }
 
     private void setSpellCheckerConfigs(SpellChecker spellChecker) {
-        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREMIXEDCASE, settings.getBoolean(Configuration.SPELL_IGNOREMIXEDCASE));
-        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREUPPERCASE, settings.getBoolean(Configuration.SPELL_IGNOREUPPERCASE));
-        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREDIGITWORDS, settings.getBoolean(Configuration.SPELL_IGNOREDIGITWORDS));
-        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES, settings.getBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREMIXEDCASE, settings.getBoolean(PluginParameter.SPELL_IGNOREMIXEDCASE));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREUPPERCASE, settings.getBoolean(PluginParameter.SPELL_IGNOREUPPERCASE));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREDIGITWORDS, settings.getBoolean(PluginParameter.SPELL_IGNOREDIGITWORDS));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES, settings.getBoolean(PluginParameter.SPELL_IGNOREINTERNETADDRESSES));
         spellChecker.getConfiguration().setInteger(PluginParameter.SPELL_THRESHOLD, settings.getInt(PluginParameter.SPELL_THRESHOLD));
     }
+
+
+    @Inject
+    public void setSettings(Settings settings) {
+        this.settings = settings;
+    }
+
 
 }

--- a/src/main/java/name/webdizz/sonar/grammar/spellcheck/SpellCheckerFactory.java
+++ b/src/main/java/name/webdizz/sonar/grammar/spellcheck/SpellCheckerFactory.java
@@ -2,28 +2,32 @@ package name.webdizz.sonar.grammar.spellcheck;
 
 import com.swabunga.spell.engine.Configuration;
 import com.swabunga.spell.event.SpellChecker;
+import name.webdizz.sonar.grammar.PluginParameter;
+import org.picocontainer.annotations.Inject;
+import org.sonar.api.BatchExtension;
+import org.sonar.api.config.Settings;
 
-public class SpellCheckerFactory {
-    private SpellChecker spellChecker;
+public class SpellCheckerFactory implements BatchExtension {
+
+    @Inject
+    private Settings settings;
 
     public SpellCheckerFactory() {
-        spellChecker = new SpellChecker();
-        setSpellCheckerConfigs();
+
     }
 
     public SpellChecker getSpellChecker() {
+        SpellChecker spellChecker = new SpellChecker();
+        setSpellCheckerConfigs(spellChecker);
         return spellChecker;
     }
 
-    private void setSpellCheckerConfigs() {
-        getSpellCheckerConfig().setBoolean(Configuration.SPELL_IGNOREMIXEDCASE, false);
-        getSpellCheckerConfig().setBoolean(Configuration.SPELL_IGNOREUPPERCASE, true);
-        getSpellCheckerConfig().setBoolean(Configuration.SPELL_IGNOREDIGITWORDS, false);
-        getSpellCheckerConfig().setBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES, true);
-    }
-
-    private Configuration getSpellCheckerConfig() {
-        return spellChecker.getConfiguration();
+    private void setSpellCheckerConfigs(SpellChecker spellChecker) {
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREMIXEDCASE, settings.getBoolean(Configuration.SPELL_IGNOREMIXEDCASE));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREUPPERCASE, settings.getBoolean(Configuration.SPELL_IGNOREUPPERCASE));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREDIGITWORDS, settings.getBoolean(Configuration.SPELL_IGNOREDIGITWORDS));
+        spellChecker.getConfiguration().setBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES, settings.getBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES));
+        spellChecker.getConfiguration().setInteger(PluginParameter.SPELL_THRESHOLD, settings.getInt(PluginParameter.SPELL_THRESHOLD));
     }
 
 }

--- a/src/main/java/name/webdizz/sonar/grammar/utils/SpellCheckerUtil.java
+++ b/src/main/java/name/webdizz/sonar/grammar/utils/SpellCheckerUtil.java
@@ -9,15 +9,19 @@ import com.swabunga.spell.engine.Configuration;
 import com.swabunga.spell.engine.Word;
 import com.swabunga.spell.event.SpellChecker;
 import com.swabunga.spell.event.StringWordTokenizer;
+import org.sonar.api.BatchExtension;
 
 /**
  * Provides utility methods for spell checking. Uses an open source API
  * <a href="http://jazzy.sourceforge.net/">Jazzy</a> for spell checking.
  */
-public class SpellCheckerUtil {
-    private SpellChecker spellChecker = new SpellCheckerFactory().getSpellChecker();
+public class SpellCheckerUtil implements BatchExtension {
 
-    public SpellCheckerUtil() {
+    private SpellCheckerFactory spellCheckerFactory;
+    private SpellChecker spellChecker = spellCheckerFactory.getSpellChecker();
+
+    public SpellCheckerUtil(SpellCheckerFactory spellCheckerFactory) {
+        this.spellCheckerFactory=spellCheckerFactory;
     }
 
     /**

--- a/src/test/java/name/webdizz/sonar/grammar/spellcheck/JavaSourceCodeWordFinderTest.java
+++ b/src/test/java/name/webdizz/sonar/grammar/spellcheck/JavaSourceCodeWordFinderTest.java
@@ -1,11 +1,9 @@
 package name.webdizz.sonar.grammar.spellcheck;
 
-import com.swabunga.spell.engine.Configuration;
 import com.swabunga.spell.engine.SpellDictionary;
 import com.swabunga.spell.event.SpellChecker;
 import name.webdizz.sonar.grammar.PluginParameter;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
@@ -14,14 +12,12 @@ import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 import org.sonar.api.config.Settings;
 
-
-
 import static com.swabunga.spell.event.SpellChecker.SPELLCHECK_OK;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-@Ignore
+
 @RunWith(Theories.class)
 public class JavaSourceCodeWordFinderTest {
     private String ERROR_MESSAGE = "This text has errors. If there are no errors, we expect 'errorsSize = -1'";
@@ -34,15 +30,17 @@ public class JavaSourceCodeWordFinderTest {
     public void init() {
         when(settings.getString(PluginParameter.DICTIONARY_PATH)).thenReturn("/dict/english.0");
 
-        when(settings.getBoolean(Configuration.SPELL_IGNOREMIXEDCASE)).thenReturn(false);
-        when(settings.getBoolean(Configuration.SPELL_IGNOREUPPERCASE)).thenReturn(true);
-        when(settings.getBoolean(Configuration.SPELL_IGNOREDIGITWORDS)).thenReturn(false);
-        when(settings.getBoolean(Configuration.SPELL_IGNOREINTERNETADDRESSES)).thenReturn(true);
+        when(settings.getBoolean(PluginParameter.SPELL_IGNOREMIXEDCASE)).thenReturn(false);
+        when(settings.getBoolean(PluginParameter.SPELL_IGNOREUPPERCASE)).thenReturn(true);
+        when(settings.getBoolean(PluginParameter.SPELL_IGNOREDIGITWORDS)).thenReturn(false);
+        when(settings.getBoolean(PluginParameter.SPELL_IGNOREINTERNETADDRESSES)).thenReturn(true);
         when(settings.getInt(PluginParameter.SPELL_THRESHOLD)).thenReturn(1);
 
-        spellChecker = new SpellCheckerFactory().getSpellChecker();
-        dictionary = new GrammarDictionaryLoader(settings).loadMainDictionary();
+        SpellCheckerFactory spellCheckerFactory = new SpellCheckerFactory();
+        spellCheckerFactory.setSettings(settings);
 
+        spellChecker = spellCheckerFactory.getSpellChecker();
+        dictionary = new GrammarDictionaryLoader(settings).loadMainDictionary();
     }
 
 
@@ -102,7 +100,7 @@ public class JavaSourceCodeWordFinderTest {
     @Test
     public void shouldCheckWordsGreaterThenMinimumWordLengthIsSet() throws Exception {
         minimumWordLength = 4;
-        when(settings.getInt(PluginParameter.MIN_WORD_LENGTH)).thenReturn(minimumWordLength);
+        when(settings.getInt(PluginParameter.SPELL_MINIMUMWORDLENGTH)).thenReturn(minimumWordLength);
         String testLine = "ert.wrn.Tesst.packaage";
 
         int errorsSize = getErrorsSize(testLine);
@@ -114,7 +112,7 @@ public class JavaSourceCodeWordFinderTest {
     @Test
     public void shouldNotCheckWordsLessThenMinimumWordLengthIsSet() throws Exception {
         minimumWordLength = 4;
-        when(settings.getInt(PluginParameter.MIN_WORD_LENGTH)).thenReturn(minimumWordLength);
+        when(settings.getInt(PluginParameter.SPELL_MINIMUMWORDLENGTH)).thenReturn(minimumWordLength);
         String testLine = "erq.zzw.test.package";
 
         int errorsSize = getErrorsSize(testLine);


### PR DESCRIPTION
Spell checking parameters now can be set via sonar GUI, parameters are divided into two sub categories - 'Dictionary' with dictionary related settings (default path, alternative dictionary, exclusion / inclusion properties) and 'Spell checker' category with settings like ignore camel case, min word length, etc...
also this commit contains small fixes after incorrect merge rebase.